### PR TITLE
Second prototype

### DIFF
--- a/ui/app/components/flex-masonry.js
+++ b/ui/app/components/flex-masonry.js
@@ -1,0 +1,66 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { run } from '@ember/runloop';
+import { action } from '@ember/object';
+import { minIndex, max } from 'd3-array';
+
+export default class FlexMasonry extends Component {
+  @tracked element = null;
+
+  @action
+  captureElement(element) {
+    this.element = element;
+  }
+
+  @action
+  reflow() {
+    run.next(() => {
+      // There's nothing to do if this is  single column layout
+      if (!this.element || this.args.columns === 1 || !this.args.columns) return;
+
+      const columns = new Array(this.args.columns).fill(null).map(() => ({
+        height: 0,
+        elements: [],
+      }));
+
+      const items = this.element.querySelectorAll('.flex-masonry-item');
+
+      // First pass: assign each element to a column based on the running heights of each column
+      for (let item of items) {
+        const styles = window.getComputedStyle(item);
+        const marginTop = parseFloat(styles.marginTop);
+        const marginBottom = parseFloat(styles.marginBottom);
+        const height = item.clientHeight;
+
+        // Pick the shortest column accounting for margins
+        const column = columns[minIndex(columns, c => c.height)];
+
+        // Add the new element's height to the column height
+        column.height += marginTop + height + marginBottom;
+        column.elements.push(item);
+      }
+
+      // Second pass: assign an order to each element based on their column and position in the column
+      columns
+        .mapBy('elements')
+        .flat()
+        .forEach((dc, index) => {
+          dc.style.order = index;
+        });
+
+      // Gaurantee column wrapping as predicted (if the first item of a column is shorter than the difference
+      // beteen the height of the column and the previous column, then flexbox will naturally place the first
+      // item at the end of the previous column).
+      columns.forEach((column, index) => {
+        const nextHeight = index < columns.length - 1 ? columns[index + 1].height : 0;
+        const item = column.elements.lastObject;
+        if (item) {
+          item.style.flexBasis = item.clientHeight + Math.max(0, nextHeight - column.height) + 'px';
+        }
+      });
+
+      // Set the max height of the container to the height of the tallest column
+      this.element.style.maxHeight = max(columns.mapBy('height')) + 1 + 'px';
+    });
+  }
+}

--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -200,6 +200,7 @@ export default class TopoViz extends Component {
       const vLeft = window.visualViewport.pageLeft;
       const vTop = window.visualViewport.pageTop;
 
+      // Lines to the memory rect of each selected allocation
       const edges = [];
       for (let allocation of selectedAllocations) {
         if (allocation !== activeEl) {
@@ -213,10 +214,23 @@ export default class TopoViz extends Component {
         }
       }
 
+      // Lines from the memory rect to the cpu rect
+      for (let allocation of selectedAllocations) {
+        const id = allocation.closest('[data-allocation-id]').dataset.allocationId;
+        const cpu = allocation
+          .closest('.topo-viz-node')
+          .querySelector(`.cpu .bar[data-allocation-id="${id}"]`);
+        const bboxMem = allocation.getBoundingClientRect();
+        const bboxCpu = cpu.getBoundingClientRect();
+        edges.push({
+          x1: bboxMem.x + bboxMem.width / 2 + vLeft,
+          y1: bboxMem.y + bboxMem.height / 2 + vTop,
+          x2: bboxCpu.x + bboxCpu.width / 2 + vLeft,
+          y2: bboxCpu.y + bboxCpu.height / 2 + vTop,
+        });
+      }
+
       this.activeEdges = edges;
     });
-    // get element for active alloc
-    // get element for all selected allocs
-    // draw lines between centroid of each
   }
 }

--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -13,6 +13,7 @@ export default class TopoViz extends Component {
   @tracked element = null;
   @tracked topology = { datacenters: [] };
 
+  @tracked activeNode = null;
   @tracked activeAllocation = null;
   @tracked activeEdges = [];
 
@@ -34,6 +35,12 @@ export default class TopoViz extends Component {
     // If there are enough nodes, use two columns of nodes within
     // a single column layout of datacenteres to increase density.
     return !this.isSingleColumn || (this.isSingleColumn && this.args.nodes.length <= 20);
+  }
+
+  // Once a cluster is large enough, the exact details of a node are
+  // typically irrelevant and a waste of space.
+  get isDense() {
+    return this.args.nodes.length > 50;
   }
 
   dataForNode(node) {
@@ -136,6 +143,21 @@ export default class TopoViz extends Component {
   }
 
   @action
+  showNodeDetails(node) {
+    if (this.activeNode) {
+      set(this.activeNode, 'isSelected', false);
+    }
+
+    this.activeNode = this.activeNode === node ? null : node;
+
+    if (this.activeNode) {
+      set(this.activeNode, 'isSelected', true);
+    }
+
+    if (this.args.onNodeSelect) this.args.onNodeSelect(this.activeNode);
+  }
+
+  @action
   associateAllocations(allocation) {
     if (this.activeAllocation === allocation) {
       this.activeAllocation = null;
@@ -151,6 +173,10 @@ export default class TopoViz extends Component {
         set(this.topology, 'selectedKey', null);
       }
     } else {
+      if (this.activeNode) {
+        set(this.activeNode, 'isSelected', false);
+      }
+      this.activeNode = null;
       this.activeAllocation = allocation;
       const selectedAllocations = this.topology.allocationIndex[this.topology.selectedKey];
       if (selectedAllocations) {
@@ -171,6 +197,7 @@ export default class TopoViz extends Component {
     }
     if (this.args.onAllocationSelect)
       this.args.onAllocationSelect(this.activeAllocation && this.activeAllocation.allocation);
+    if (this.args.onNodeSelect) this.args.onNodeSelect(this.activeNode);
   }
 
   @action

--- a/ui/app/components/topo-viz.js
+++ b/ui/app/components/topo-viz.js
@@ -4,24 +4,36 @@ import { action, set } from '@ember/object';
 import { run } from '@ember/runloop';
 import { task } from 'ember-concurrency';
 import { scaleLinear } from 'd3-scale';
-import { extent } from 'd3-array';
+import { extent, deviation, mean, minIndex, max } from 'd3-array';
 import RSVP from 'rsvp';
 
 export default class TopoViz extends Component {
   @tracked heightScale = null;
   @tracked isLoaded = false;
   @tracked element = null;
-  @tracked topology = {};
+  @tracked topology = { datacenters: [] };
 
   @tracked activeAllocation = null;
   @tracked activeEdges = [];
 
-  get activeTaskGroup() {
-    return this.activeAllocation && this.activeAllocation.taskGroupName;
+  get isSingleColumn() {
+    if (this.topology.datacenters.length <= 1) return true;
+
+    // Compute the coefficient of variance to determine if it would be
+    // better to stack datacenters or place them in columns
+    const nodeCounts = this.topology.datacenters.map(datacenter => datacenter.nodes.length);
+    const variationCoefficient = deviation(nodeCounts) / mean(nodeCounts);
+
+    // The point at which the varation is too extreme for a two column layout
+    const threshold = 0.3;
+    if (variationCoefficient > threshold) return true;
+    return false;
   }
 
-  get activeJobId() {
-    return this.activeAllocation && this.activeAllocation.belongsTo('job').id();
+  get datacenterIsSingleColumn() {
+    // If there are enough nodes, use two columns of nodes within
+    // a single column layout of datacenteres to increase density.
+    return this.columnsCount !== 1 || this.args.nodes.length <= 20;
   }
 
   dataForNode(node) {
@@ -126,21 +138,44 @@ export default class TopoViz extends Component {
   @action
   masonry() {
     run.next(() => {
+      const columnCount = this.isSingleColumn ? 1 : 2;
+
+      // There's nothing to do if this is  single column layout
+      if (columnCount === 1) return;
+
+      const columns = new Array(columnCount).fill(null).map(() => ({
+        height: 0,
+        elements: [],
+      }));
+
       const datacenterSections = this.element.querySelectorAll('.topo-viz-datacenter');
-      const elementStyles = window.getComputedStyle(this.element);
-      if (!elementStyles) return;
 
-      const rowHeight = parseInt(elementStyles.getPropertyValue('grid-auto-rows')) || 0;
-      const rowGap = parseInt(elementStyles.getPropertyValue('grid-row-gap')) || 0;
-
-      if (!rowHeight) return;
-
+      // First pass: assign each element to a column based on the running heights of each column
       for (let dc of datacenterSections) {
-        const contents = dc.querySelector('.masonry-container');
-        const height = contents.getBoundingClientRect().height;
-        const rowSpan = Math.ceil((height + rowGap) / (rowHeight + rowGap));
-        dc.style.gridRowEnd = `span ${rowSpan}`;
+        const styles = window.getComputedStyle(dc);
+        const marginTop = parseFloat(styles.marginTop);
+        const marginBottom = parseFloat(styles.marginBottom);
+        const height = dc.clientHeight;
+
+        // Pick the shortest column accounting for margins
+        const column = columns[minIndex(columns, c => c.height)];
+
+        // Add the new element's height to the column height
+        column.height += marginTop + height + marginBottom;
+        column.elements.push(dc);
       }
+
+      // Second pass: assign an order to each element based on their column and position in the column
+      columns
+        .mapBy('elements')
+        .flat()
+        .forEach((dc, index) => {
+          dc.style.order = index;
+        });
+
+      // Set the max height of the container to the height of the tallest column
+      this.element.querySelector('.topo-viz-datacenters').style.maxHeight =
+        max(columns.mapBy('height')) + 1 + 'px';
     });
   }
 

--- a/ui/app/components/topo-viz/datacenter.js
+++ b/ui/app/components/topo-viz/datacenter.js
@@ -1,19 +1,13 @@
-import RSVP from 'rsvp';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class TopoVizNode extends Component {
+export default class TopoVizDatacenter extends Component {
   @tracked scheduledAllocations = [];
   @tracked aggregatedNodeResources = { cpu: 0, memory: 0 };
-  @tracked isLoaded = false;
-
-  get aggregateNodeResources() {
-    return this.args.nodes.mapBy('resources');
-  }
 
   get aggregatedAllocationResources() {
-    return this.scheduledAllocations.mapBy('resources').reduce(
+    return this.scheduledAllocations.reduce(
       (totals, allocation) => {
         totals.cpu += allocation.cpu;
         totals.memory += allocation.memory;
@@ -24,15 +18,13 @@ export default class TopoVizNode extends Component {
   }
 
   @action
-  async loadAllocations() {
-    await RSVP.all(this.args.nodes.mapBy('allocations'));
-
-    this.scheduledAllocations = this.args.nodes.reduce(
-      (all, node) => all.concat(node.allocations.filterBy('isScheduled')),
+  loadAllocations() {
+    this.scheduledAllocations = this.args.datacenter.nodes.reduce(
+      (all, node) => all.concat(node.allocations.filterBy('allocation.isScheduled')),
       []
     );
 
-    this.aggregatedNodeResources = this.args.nodes.mapBy('resources').reduce(
+    this.aggregatedNodeResources = this.args.datacenter.nodes.reduce(
       (totals, node) => {
         totals.cpu += node.cpu;
         totals.memory += node.memory;
@@ -41,7 +33,6 @@ export default class TopoVizNode extends Component {
       { cpu: 0, memory: 0 }
     );
 
-    this.isLoaded = true;
     this.args.onLoad && this.args.onLoad();
   }
 }

--- a/ui/app/components/topo-viz/node.js
+++ b/ui/app/components/topo-viz/node.js
@@ -99,6 +99,13 @@ export default class TopoVizNode extends Component {
   }
 
   @action
+  selectNode() {
+    if (this.args.isDense && this.args.onNodeSelect) {
+      this.args.onNodeSelect(this.args.node.isSelected ? null : this.args.node);
+    }
+  }
+
+  @action
   selectAllocation(allocation) {
     if (this.args.onAllocationSelect) this.args.onAllocationSelect(allocation);
   }

--- a/ui/app/styles/charts/topo-viz-node.scss
+++ b/ui/app/styles/charts/topo-viz-node.scss
@@ -62,6 +62,10 @@
   }
 }
 
+.flex-masonry-columns-2 > .flex-masonry-item > .chart.topo-viz-node svg {
+  width: calc(100% - 0.75em);
+}
+
 .chart.topo-viz-edges {
   width: 100%;
   height: 100%;

--- a/ui/app/styles/charts/topo-viz-node.scss
+++ b/ui/app/styles/charts/topo-viz-node.scss
@@ -11,6 +11,17 @@
       fill: $white-ter;
       stroke-width: 1;
       stroke: $grey-lighter;
+
+      &.is-interactive:hover {
+        fill: $white;
+        stroke: $grey-light;
+      }
+
+      &.is-selected,
+      &.is-selected:hover {
+        fill: $white;
+        stroke: $grey;
+      }
     }
 
     .dimension-background {
@@ -42,6 +53,7 @@
       alignment-baseline: central;
       font-weight: $weight-normal;
       fill: $grey;
+      pointer-events: none;
     }
   }
 

--- a/ui/app/styles/charts/topo-viz.scss
+++ b/ui/app/styles/charts/topo-viz.scss
@@ -1,11 +1,19 @@
 .topo-viz {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  column-gap: 1.5em;
-  row-gap: 1.5em;
-  grid-auto-rows: 10px;
+  .topo-viz-datacenters {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-content: space-between;
+    margin-top: -0.75em;
 
-  &.is-single-column {
-    grid-template-columns: 100%;
+    .topo-viz-datacenter {
+      margin-top: 0.75em;
+      margin-bottom: 0.75em;
+      width: calc(50% - 0.75em);
+    }
+  }
+
+  &.is-single-column .topo-viz-datacenter {
+    width: 100%;
   }
 }

--- a/ui/app/styles/components.scss
+++ b/ui/app/styles/components.scss
@@ -12,6 +12,7 @@
 @import './components/event';
 @import './components/exec-button';
 @import './components/exec-window';
+@import './components/flex-masonry';
 @import './components/fs-explorer';
 @import './components/global-search-container';
 @import './components/global-search-dropdown';

--- a/ui/app/styles/components/flex-masonry.scss
+++ b/ui/app/styles/components/flex-masonry.scss
@@ -1,0 +1,37 @@
+.flex-masonry {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-content: space-between;
+  margin-top: -0.75em;
+
+  &.flex-masonry-columns-1 > .flex-masonry-item {
+    width: 100%;
+  }
+  &.flex-masonry-columns-2 > .flex-masonry-item {
+    width: 50%;
+  }
+  &.flex-masonry-columns-3 > .flex-masonry-item {
+    width: 33%;
+  }
+  &.flex-masonry-columns-4 > .flex-masonry-item {
+    width: 25%;
+  }
+
+  &.with-spacing {
+    > .flex-masonry-item {
+      margin-top: 0.75em;
+      margin-bottom: 0.75em;
+    }
+
+    &.flex-masonry-columns-2 > .flex-masonry-item {
+      width: calc(50% - 0.75em);
+    }
+    &.flex-masonry-columns-3 > .flex-masonry-item {
+      width: calc(33% - 0.75em);
+    }
+    &.flex-masonry-columns-4 > .flex-masonry-item {
+      width: calc(25% - 0.75em);
+    }
+  }
+}

--- a/ui/app/templates/components/flex-masonry.hbs
+++ b/ui/app/templates/components/flex-masonry.hbs
@@ -1,0 +1,11 @@
+<div
+  class="flex-masonry {{if @withSpacing "with-spacing"}} flex-masonry-columns-{{@columns}}"
+  {{did-insert this.captureElement}}
+  {{did-insert this.reflow}}
+  {{did-update this.reflow}}>
+  {{#each @items as |item|}}
+    <div class="flex-masonry-item">
+      {{yield item (action this.reflow)}}
+    </div>
+  {{/each}}
+</div>

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -1,4 +1,4 @@
-<div class="topo-viz {{if (or this.buildTopology.isRunning (eq this.datacenters.length 1)) "is-single-column"}}" {{did-insert (perform this.buildTopology)}} {{did-insert this.captureElement}}>
+<div class="topo-viz {{if (or this.buildTopology.isRunning this.isSingleColumn) "is-single-column"}}" {{did-insert (perform this.buildTopology)}} {{did-insert this.captureElement}}>
   {{#if this.buildTopology.isRunning}}
     <div class="has-text-centered">
       <h2 class="title">Loading. If you have a lot of clients this may take awhile</h2>
@@ -6,13 +6,16 @@
       <LoadingSpinner />
     </div>
   {{else}}
-    {{#each this.topology.datacenters as |dc|}}
-      <TopoViz::Datacenter
-        @datacenter={{dc}}
-        @heightScale={{this.topology.heightScale}}
-        @onAllocationSelect={{this.associateAllocations}}
-        @onLoad={{action this.masonry}}/>
-    {{/each}}
+    <div class="topo-viz-datacenters">
+      {{#each this.topology.datacenters as |dc|}}
+        <TopoViz::Datacenter
+          @datacenter={{dc}}
+          @isSingleColumn={{this.datacenterIsSingleColumn}}
+          @heightScale={{this.topology.heightScale}}
+          @onAllocationSelect={{this.associateAllocations}}
+          @onLoad={{action this.masonry}}/>
+      {{/each}}
+    </div>
 
     {{#if this.activeAllocation}}
       <svg class="chart topo-viz-edges" {{window-resize this.computedActiveEdges}}>

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -1,13 +1,12 @@
-<div class="topo-viz {{if (eq this.datacenters.length 1) "is-single-column"}}" {{did-insert this.loadNodes}} {{did-insert this.captureElement}}>
-  {{#if this.isLoaded}}
-    {{#each this.datacenters as |dc|}}
+<div class="topo-viz {{if (eq this.datacenters.length 1) "is-single-column"}}" {{did-insert (perform this.buildTopology)}} {{did-insert this.captureElement}}>
+  {{#if this.buildTopology.isRunning}}
+    <div class="has-text-centered"><LoadingSpinner /></div>
+  {{else}}
+    {{#each this.topology.datacenters as |dc|}}
       <TopoViz::Datacenter
-        @datacenter={{dc.name}}
-        @nodes={{dc.nodes}}
-        @heightScale={{this.heightScale}}
+        @datacenter={{dc}}
+        @heightScale={{this.topology.heightScale}}
         @onAllocationSelect={{this.associateAllocations}}
-        @activeTaskGroup={{this.activeTaskGroup}}
-        @activeJobId={{this.activeJobId}}
         @onLoad={{action this.masonry}}/>
     {{/each}}
 

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -10,8 +10,10 @@
       <TopoViz::Datacenter
           @datacenter={{dc}}
           @isSingleColumn={{this.datacenterIsSingleColumn}}
+          @isDense={{this.isDense}}
           @heightScale={{this.topology.heightScale}}
           @onAllocationSelect={{this.associateAllocations}}
+          @onNodeSelect={{this.showNodeDetails}}
           @onLoad={{action reflow}}/>
     </FlexMasonry>
 

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -1,6 +1,10 @@
-<div class="topo-viz {{if (eq this.datacenters.length 1) "is-single-column"}}" {{did-insert (perform this.buildTopology)}} {{did-insert this.captureElement}}>
+<div class="topo-viz {{if (or this.buildTopology.isRunning (eq this.datacenters.length 1)) "is-single-column"}}" {{did-insert (perform this.buildTopology)}} {{did-insert this.captureElement}}>
   {{#if this.buildTopology.isRunning}}
-    <div class="has-text-centered"><LoadingSpinner /></div>
+    <div class="has-text-centered">
+      <h2 class="title">Loading. If you have a lot of clients this may take awhile</h2>
+      <p>Every client needs to be loaded individually. This is a shortcoming of the prototype and will be fixed before this is graduated to the actual Nomad project.</p>
+      <LoadingSpinner />
+    </div>
   {{else}}
     {{#each this.topology.datacenters as |dc|}}
       <TopoViz::Datacenter

--- a/ui/app/templates/components/topo-viz.hbs
+++ b/ui/app/templates/components/topo-viz.hbs
@@ -6,16 +6,14 @@
       <LoadingSpinner />
     </div>
   {{else}}
-    <div class="topo-viz-datacenters">
-      {{#each this.topology.datacenters as |dc|}}
-        <TopoViz::Datacenter
+    <FlexMasonry @columns={{if this.isSingleColumn 1 2}} @items={{this.topology.datacenters}} @withSpacing={{true}} as |dc reflow|>
+      <TopoViz::Datacenter
           @datacenter={{dc}}
           @isSingleColumn={{this.datacenterIsSingleColumn}}
           @heightScale={{this.topology.heightScale}}
           @onAllocationSelect={{this.associateAllocations}}
-          @onLoad={{action this.masonry}}/>
-      {{/each}}
-    </div>
+          @onLoad={{action reflow}}/>
+    </FlexMasonry>
 
     {{#if this.activeAllocation}}
       <svg class="chart topo-viz-edges" {{window-resize this.computedActiveEdges}}>

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -10,8 +10,10 @@
     <FlexMasonry @columns={{if @isSingleColumn 1 2}} @items={{@datacenter.nodes}} as |node|>
       <TopoViz::Node
         @node={{node}}
+        @isDense={{@isDense}}
         @heightScale={{@heightScale}}
-        @onAllocationSelect={{@onAllocationSelect}} />
+        @onAllocationSelect={{@onAllocationSelect}}
+        @onNodeSelect={{@onNodeSelect}}/>
     </FlexMasonry>
   </div>
 </div>

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -1,19 +1,17 @@
 <div class="boxed-section topo-viz-datacenter" {{did-insert this.loadAllocations}}>
-  <div class="masonry-container">
-    <div class="boxed-section-head is-hollow">
-      <strong>{{@datacenter.name}}</strong>
-      <span class="bumper-left">{{this.scheduledAllocations.length}} Allocs</span>
-      <span class="bumper-left">{{@datacenter.nodes.length}} Nodes</span>
-      <span class="bumper-left is-faded">{{this.aggregatedAllocationResources.memory}}/{{this.aggregatedNodeResources.memory}} MiB,
-        {{this.aggregatedAllocationResources.cpu}}/{{this.aggregatedNodeResources.cpu}} Mhz</span>
-    </div>
-    <div class="boxed-section-body">
-      {{#each @datacenter.nodes as |node|}}
-        <TopoViz::Node
-          @node={{node}}
-          @heightScale={{@heightScale}}
-          @onAllocationSelect={{@onAllocationSelect}} />
-      {{/each}}
-    </div>
+  <div class="boxed-section-head is-hollow">
+    <strong>{{@datacenter.name}}</strong>
+    <span class="bumper-left">{{this.scheduledAllocations.length}} Allocs</span>
+    <span class="bumper-left">{{@datacenter.nodes.length}} Nodes</span>
+    <span class="bumper-left is-faded">{{this.aggregatedAllocationResources.memory}}/{{this.aggregatedNodeResources.memory}} MiB,
+      {{this.aggregatedAllocationResources.cpu}}/{{this.aggregatedNodeResources.cpu}} Mhz</span>
+  </div>
+  <div class="boxed-section-body">
+    {{#each @datacenter.nodes as |node|}}
+      <TopoViz::Node
+        @node={{node}}
+        @heightScale={{@heightScale}}
+        @onAllocationSelect={{@onAllocationSelect}} />
+    {{/each}}
   </div>
 </div>

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -1,23 +1,19 @@
 <div class="boxed-section topo-viz-datacenter" {{did-insert this.loadAllocations}}>
   <div class="masonry-container">
     <div class="boxed-section-head is-hollow">
-      <strong>{{@datacenter}}</strong>
+      <strong>{{@datacenter.name}}</strong>
       <span class="bumper-left">{{this.scheduledAllocations.length}} Allocs</span>
-      <span class="bumper-left">{{@nodes.length}} Nodes</span>
+      <span class="bumper-left">{{@datacenter.nodes.length}} Nodes</span>
       <span class="bumper-left is-faded">{{this.aggregatedAllocationResources.memory}}/{{this.aggregatedNodeResources.memory}} MiB,
         {{this.aggregatedAllocationResources.cpu}}/{{this.aggregatedNodeResources.cpu}} Mhz</span>
     </div>
     <div class="boxed-section-body">
-      {{#if this.isLoaded}}
-        {{#each @nodes as |node|}}
-          <TopoViz::Node
-            @node={{node}}
-            @heightScale={{@heightScale}}
-            @onAllocationSelect={{@onAllocationSelect}}
-            @activeTaskGroup={{@activeTaskGroup}}
-            @activeJobId={{@activeJobId}} />
-        {{/each}}
-      {{/if}}
+      {{#each @datacenter.nodes as |node|}}
+        <TopoViz::Node
+          @node={{node}}
+          @heightScale={{@heightScale}}
+          @onAllocationSelect={{@onAllocationSelect}} />
+      {{/each}}
     </div>
   </div>
 </div>

--- a/ui/app/templates/components/topo-viz/datacenter.hbs
+++ b/ui/app/templates/components/topo-viz/datacenter.hbs
@@ -7,11 +7,11 @@
       {{this.aggregatedAllocationResources.cpu}}/{{this.aggregatedNodeResources.cpu}} Mhz</span>
   </div>
   <div class="boxed-section-body">
-    {{#each @datacenter.nodes as |node|}}
+    <FlexMasonry @columns={{if @isSingleColumn 1 2}} @items={{@datacenter.nodes}} as |node|>
       <TopoViz::Node
         @node={{node}}
         @heightScale={{@heightScale}}
         @onAllocationSelect={{@onAllocationSelect}} />
-    {{/each}}
+    </FlexMasonry>
   </div>
 </div>

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -1,16 +1,18 @@
 <div class="chart topo-viz-node {{unless this.allocations.length "is-empty"}}" {{did-insert this.reloadNode}}>
-  <p>
-    <strong>{{@node.node.name}}</strong>
-    <span class="bumper-left">{{this.count}} Allocs</span>
-    <span class="bumper-left is-faded">{{@node.memory}} MiB, {{@node.cpu}} Mhz</span>
-  </p>
+  {{#unless @isDense}}
+    <p>
+      <strong>{{@node.node.name}}</strong>
+      <span class="bumper-left">{{this.count}} Allocs</span>
+      <span class="bumper-left is-faded">{{@node.memory}} MiB, {{@node.cpu}} Mhz</span>
+    </p>
+  {{/unless}}
   <svg class="chart" height="{{this.totalHeight}}px" {{did-insert this.render}} {{did-update this.updateRender}} {{window-resize this.render}}>
     <defs>
       <clipPath id="{{this.maskId}}">
         <rect class="mask" x="0" y="0" width="{{this.dimensionsWidth}}px" height="{{this.maskHeight}}px" rx="2px" ry="2px" />
       </clipPath>
     </defs>
-    <rect class="node-background" width="100%" height="{{this.totalHeight}}px" rx="2px" ry="2px" />
+    <rect class="node-background {{if @node.isSelected "is-selected"}} {{if @isDense "is-interactive"}}" width="100%" height="{{this.totalHeight}}px" rx="2px" ry="2px" {{on "click" this.selectNode}} />
     {{#if this.allocations.length}}
       <g
         class="dimensions {{if this.activeAllocation "is-active"}}"

--- a/ui/app/templates/components/topo-viz/node.hbs
+++ b/ui/app/templates/components/topo-viz/node.hbs
@@ -1,10 +1,10 @@
 <div class="chart topo-viz-node {{unless this.allocations.length "is-empty"}}" {{did-insert this.reloadNode}}>
   <p>
-    <strong>{{@node.name}}</strong>
+    <strong>{{@node.node.name}}</strong>
     <span class="bumper-left">{{this.count}} Allocs</span>
-    <span class="bumper-left is-faded">{{@node.resources.memory}} MiB, {{@node.resources.cpu}} Mhz</span>
+    <span class="bumper-left is-faded">{{@node.memory}} MiB, {{@node.cpu}} Mhz</span>
   </p>
-  <svg class="chart" height="{{this.totalHeight}}px" {{did-insert this.render}} {{did-update this.updateRender @activeTaskGroup @activeJobId}} {{window-resize this.render}}>
+  <svg class="chart" height="{{this.totalHeight}}px" {{did-insert this.render}} {{did-update this.updateRender}} {{window-resize this.render}}>
     <defs>
       <clipPath id="{{this.maskId}}">
         <rect class="mask" x="0" y="0" width="{{this.dimensionsWidth}}px" height="{{this.maskHeight}}px" rx="2px" ry="2px" />
@@ -33,23 +33,23 @@
           {{/if}}
           {{#each this.data.memory key="allocation.id" as |memory|}}
             <g
-              class="bar {{memory.className}} {{if (eq this.activeAllocation memory.allocation) "is-active"}} {{if memory.isSelected "is-selected"}}"
+              class="bar {{memory.className}} {{if (eq this.activeAllocation memory.allocation) "is-active"}} {{if memory.allocation.isSelected "is-selected"}}"
               clip-path="url(#{{this.maskId}})"
-              data-allocation-id="{{memory.allocation.id}}"
+              data-allocation-id="{{memory.allocation.allocation.id}}"
               {{on "mouseenter" (fn this.highlightAllocation memory.allocation)}}
               {{on "click" (fn this.selectAllocation memory.allocation)}}>
               <rect
                 width="{{memory.width}}px"
-                height="{{if memory.isSelected this.selectedHeight this.height}}px"
+                height="{{if memory.allocation.isSelected this.selectedHeight this.height}}px"
                 x="{{memory.x}}px"
-                y="{{if memory.isSelected 0.5 0}}px"
+                y="{{if memory.allocation.isSelected 0.5 0}}px"
                 class="layer-0" />
               {{#if (or (eq memory.className "starting") (eq memory.className "pending"))}}
                 <rect
                   width="{{memory.width}}px"
-                  height="{{if memory.isSelected this.selectedHeight this.height}}px"
+                  height="{{if memory.allocation.isSelected this.selectedHeight this.height}}px"
                   x="{{memory.x}}px"
-                  y="{{if memory.isSelected 0.5 0}}px"
+                  y="{{if memory.allocation.isSelected 0.5 0}}px"
                   class="layer-1" />
               {{/if}}
             </g>
@@ -69,23 +69,23 @@
           {{/if}}
           {{#each this.data.cpu key="allocation.id" as |cpu|}}
             <g
-              class="bar {{cpu.className}} {{if (eq this.activeAllocation cpu.allocation) "is-active"}} {{if cpu.isSelected "is-selected"}}"
+              class="bar {{cpu.className}} {{if (eq this.activeAllocation cpu.allocation) "is-active"}} {{if cpu.allocation.isSelected "is-selected"}}"
               clip-path="url(#{{this.maskId}})"
-              data-allocation-id="{{cpu.allocation.id}}"
+              data-allocation-id="{{cpu.allocation.allocation.id}}"
               {{on "mouseenter" (fn this.highlightAllocation cpu.allocation)}}
               {{on "click" (fn this.selectAllocation cpu.allocation)}}>
               <rect
                 width="{{cpu.width}}px"
-                height="{{if cpu.isSelected this.selectedHeight this.height}}px"
+                height="{{if cpu.allocation.isSelected this.selectedHeight this.height}}px"
                 x="{{cpu.x}}px"
-                y="{{if cpu.isSelected this.selectedYOffset this.yOffset}}px"
+                y="{{if cpu.allocation.isSelected this.selectedYOffset this.yOffset}}px"
                 class="layer-0" />
               {{#if (or (eq cpu.className "starting") (eq cpu.className "pending"))}}
                 <rect
                   width="{{cpu.width}}px"
-                  height="{{if cpu.isSelected this.selectedHeight this.height}}px"
+                  height="{{if cpu.allocation.isSelected this.selectedHeight this.height}}px"
                   x="{{cpu.x}}px"
-                  y="{{if cpu.isSelected this.selectedYOffset this.yOffset}}px"
+                  y="{{if cpu.allocation.isSelected this.selectedYOffset this.yOffset}}px"
                   class="layer-1" />
               {{/if}}
             </g>

--- a/ui/app/templates/topology.hbs
+++ b/ui/app/templates/topology.hbs
@@ -24,9 +24,67 @@
           </div>
         </div>
         <div class="boxed-section">
-          <div class="boxed-section-head">{{if this.activeAllocation "Allocation" "Cluster"}} Details</div>
+          <div class="boxed-section-head">
+            {{#if this.activeNode}}Client{{else if this.activeAllocation}}Allocation{{else}}Cluster{{/if}} Details
+          </div>
           <div class="boxed-section-body">
-            {{#if this.activeAllocation}}
+            {{#if this.activeNode}}
+              <div class="dashboard-metric">
+                <p class="metric">{{this.activeNode.allocations.length}} <span class="metric-label">Allocations</span></p>
+              </div>
+              <div class="dashboard-metric">
+                <h3 class="pair">
+                  <strong>Client:</strong>
+                  <LinkTo @route="clients.client" @model={{this.activeNode.node}}>
+                    {{this.activeNode.node.shortId}}
+                  </LinkTo>
+                </h3>
+                <p><strong>Name:</strong> {{this.activeNode.node.name}}</p>
+                <p><strong>Address:</strong> {{this.activeNode.node.httpAddr}}</p>
+              </div>
+              <div class="dashboard-metric with-divider">
+                <p class="metric">{{this.nodeUtilization.totalMemoryFormatted}} <span class="metric-units">{{this.nodeUtilization.totalMemoryUnits}}</span> <span class="metric-label">of memory</span></p>
+                <div class="columns graphic">
+                  <div class="column">
+                    <div class="inline-chart" data-test-percentage-bar>
+                      <progress
+                        class="progress is-danger is-small"
+                        value="{{this.nodeUtilization.reservedMemoryPercent}}"
+                        max="1">
+                        {{this.nodeUtilization.reservedMemoryPercent}}
+                      </progress>
+                    </div>
+                  </div>
+                  <div class="column is-minimum">
+                    <span class="nowrap" data-test-percentage>{{format-percentage this.nodeUtilization.reservedMemoryPercent total=1}}</span>
+                  </div>
+                </div>
+                <div class="annotation" data-test-absolute-value>
+                  <strong>{{format-bytes this.nodeUtilization.totalReservedMemory}}</strong> / {{format-bytes this.nodeUtilization.totalMemory}} reserved
+                </div>
+              </div>
+              <div class="dashboard-metric">
+                <p class="metric">{{this.nodeUtilization.totalCPU}} <span class="metric-units">Mhz</span> <span class="metric-label">of CPU</span></p>
+                <div class="columns graphic">
+                  <div class="column">
+                    <div class="inline-chart" data-test-percentage-bar>
+                      <progress
+                        class="progress is-info is-small"
+                        value="{{this.nodeUtilization.reservedCPUPercent}}"
+                        max="1">
+                        {{this.nodeUtilization.reservedCPUPercent}}
+                      </progress>
+                    </div>
+                  </div>
+                  <div class="column is-minimum">
+                    <span class="nowrap" data-test-percentage>{{format-percentage this.nodeUtilization.reservedCPUPercent total=1}}</span>
+                  </div>
+                </div>
+                <div class="annotation" data-test-absolute-value>
+                  <strong>{{this.nodeUtilization.totalReservedCPU}} Mhz</strong> / {{this.nodeUtilization.totalCPU}} Mhz reserved
+                </div>
+              </div>
+            {{else if this.activeAllocation}}
               <div class="dashboard-metric">
                 <h3 class="pair">
                   <strong>Allocation:</strong>
@@ -121,7 +179,11 @@
         </div>
       </div>
       <div class="column">
-        <TopoViz @nodes={{this.model.nodes}} @allocations={{this.model.allocations}} @onAllocationSelect={{action this.setAllocation}} />
+        <TopoViz
+          @nodes={{this.model.nodes}}
+          @allocations={{this.model.allocations}}
+          @onAllocationSelect={{action this.setAllocation}}
+          @onNodeSelect={{action this.setNode}} />
       </div>
     </div>
   </section>

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "bulma": "0.6.1",
     "core-js": "^2.4.1",
-    "d3-array": "^1.2.0",
+    "d3-array": "^2.1.0",
     "d3-axis": "^1.0.0",
     "d3-format": "^1.3.0",
     "d3-scale": "^1.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8312,6 +8312,11 @@ d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+d3-array@^2.1.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
+  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
+
 d3-axis@^1.0.0:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"


### PR DESCRIPTION
This does a couple things

1. **Performance:** By constructing a single data structure up top and eliminating calculations on the node components, we save on repetitive computation. This is allows for more allocations to render more quickly. It also makes drawing lines faster.
2. **Density:** The visualization is now more adaptive to the cluster state. If the distributions of nodes across datacenters isn't particularly uniform, then datacenters will be shown in a single column layout. If there are a lot of nodes in a single column layout then the nodes within a datacenter will be shown across two columns. Lastly, if there are just a lot of nodes period then the static node labels go away in favor of makes nodes interactive with details showing up in the info pane.